### PR TITLE
Indecisive Devices - Add mecanum drive v1

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
@@ -1,19 +1,14 @@
 package org.firstinspires.ftc.teamcode.teamcode;
 
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
-import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.IMU;
-import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 
 @TeleOp(name = "Decode2025RobotCode_TeleOp", group = "Robot")
-@Disabled
 public class Decode2025RobotCode_TeleOp extends OpMode {
-
     public DcMotor frontLeftDrive = null;
     public DcMotor frontRightDrive  = null;
     public DcMotor rearLeftDrive = null;
@@ -40,7 +35,7 @@ public class Decode2025RobotCode_TeleOp extends OpMode {
 
         RevHubOrientationOnRobot RevOrientation = new RevHubOrientationOnRobot(
                 RevHubOrientationOnRobot.LogoFacingDirection.UP,
-                RevHubOrientationOnRobot.UsbFacingDirection.FORWARD);
+                RevHubOrientationOnRobot.UsbFacingDirection.BACKWARD);
 
         imu.initialize(new IMU.Parameters(RevOrientation));
     }
@@ -66,11 +61,14 @@ public class Decode2025RobotCode_TeleOp extends OpMode {
 
     }
 
-
+    double forward, strafe, rotate;
 
     @Override
     public void loop() {
+        forward = -gamepad1.left_stick_y;
+        strafe = gamepad1.left_stick_x;
+        rotate = gamepad1. right_stick_x;
 
+        drive(forward, strafe, rotate);
     }
 }
-

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
@@ -50,7 +50,24 @@ public class Decode2025RobotCode_TeleOp extends OpMode {
         double rearLeftDrive = forward - strafe + rotate;
         double frontRightDrive = forward - strafe - rotate;
         double rearRightDrive = forward + strafe - rotate;
+
+        double maxPower = 1.0;
+        double maxSpeed = 1.0;
+
+        maxPower = Math.max(maxPower, Math.abs(frontLeftDrive));
+        maxPower = Math.max(maxPower, Math.abs(rearLeftDrive));
+        maxPower = Math.max(maxPower, Math.abs(frontRightDrive));
+        maxPower = Math.max(maxPower, Math.abs(rearRightDrive));
+
+        this.frontLeftDrive.setPower(maxSpeed * (frontLeftDrive/ maxPower));
+        this.rearRightDrive.setPower(maxSpeed * (rearRightDrive/ maxPower));
+        this.rearLeftDrive.setPower(maxSpeed * (rearLeftDrive/ maxPower));
+        this.frontRightDrive.setPower(maxSpeed * (frontRightDrive/ maxPower));
+
     }
+
+
+
     @Override
     public void loop() {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
@@ -1,104 +1,35 @@
-/*   MIT License
- *   Copyright (c) [2024] [Base 10 Assets, LLC]
- *
- *   Permission is hereby granted, free of charge, to any person obtaining a copy
- *   of this software and associated documentation files (the "Software"), to deal
- *   in the Software without restriction, including without limitation the rights
- *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *   copies of the Software, and to permit persons to whom the Software is
- *   furnished to do so, subject to the following conditions:
-
- *   The above copyright notice and this permission notice shall be included in all
- *   copies or substantial portions of the Software.
-
- *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *   SOFTWARE.
- */
-
 package org.firstinspires.ftc.teamcode.teamcode;
 
-import androidx.fragment.app.FragmentContainer;
-
-import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.hardware.CRServo;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.Servo;
-
-import org.firstinspires.ftc.robotcore.external.navigation.CurrentUnit;
-
-/*
- * This OpMode is an example driver-controlled (TeleOp) mode for the goBILDA 2024-2025 FTC
- * Into The Deep Starter Robot
- * The code is structured as a LinearOpMode
- *
- * This robot has a two-motor differential-steered (sometimes called tank or skid steer) drivetrain.
- * With a left and right drive motor.
- * The drive on this robot is controlled in an "Arcade" style, with the left stick Y axis
- * controlling the forward movement and the right stick X axis controlling rotation.
- * This allows easy transition to a standard "First Person" control of a
- * mecanum or omnidirectional chassis.
- *
- * The drive wheels are 96mm diameter traction (Rhino) or omni wheels.
- * They are driven by 2x 5203-2402-0019 312RPM Yellow Jacket Planetary Gearmotors.
- *
- * This robot's main scoring mechanism includes an arm powered by a motor, a "wrist" driven
- * by a servo, and an intake driven by a continuous rotation servo.
- *
- * The arm is powered by a 5203-2402-0051 (50.9:1 Yellow Jacket Planetary Gearmotor) with an
- * external 5:1 reduction. This creates a total ~254.47:1 reduction.
- * This OpMode uses the motor's encoder and the RunToPosition method to drive the arm to
- * specific setpoints. These are defined as a number of degrees of rotation away from the arm's
- * starting position.
- *
- * Make super sure that the arm is reset into the robot, and the wrist is folded in before
- * you run start the OpMode. The motor's encoder is "relative" and will move the number of degrees
- * you request it to based on the starting position. So if it starts too high, all the motor
- * setpoints will be wrong.
- *
- * The wrist is powered by a goBILDA Torque Servo (2000-0025-0002).
- *0.
- * The intake wheels are powered by a goBILDA Speed Servo (2000-0025-0003) in Continuous Rotation mode.
- */
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
 
 @TeleOp(name = "Decode2025RobotCode_TeleOp", group = "Robot")
-// @Disabled
-public class Decode2025RobotCode_TeleOp extends LinearOpMode {
+@Disabled
+public class Decode2025RobotCode_TeleOp extends OpMode {
 
-    /* Declare OpMode members. */
-    public DcMotor  frontLeftDrive = null; //the left drivetrain motor
-    public DcMotor  frontRightDrive  = null; //the right drivetrain motor
-    public DcMotor  rearLeftDrive = null; //the left drivetrain motor
-    public DcMotor  rearRightDrive  = null; //the right drivetrain motor
-
+    public DcMotor frontLeftDrive = null;
+    public DcMotor frontRightDrive  = null;
+    public DcMotor rearLeftDrive = null;
+    public DcMotor rearRightDrive  = null;
 
     @Override
-    public void runOpMode() {
-        /*
-         * These variables are private to the OpMode, and are used to control the
-         * drivetrain.
-         */
-        double left;
-        double right;
-        double forward;
-        double rotate;
-        double max;
+    public void init() {
+        frontLeftDrive = hardwareMap.get(DcMotor.class, "frontLeft_motor");
+        frontRightDrive = hardwareMap.get(DcMotor.class, "frontRight_motor");
+        rearLeftDrive = hardwareMap.get(DcMotor.class, "rearLeft_motor");
+        rearRightDrive = hardwareMap.get(DcMotor.class, "rearRight_motor");
 
-        /* Define and Initialize Motors */
-        frontLeftDrive = hardwareMap.get(DcMotor.class, "frontLeft_motor"); // the left drivetrain motor
-        frontRightDrive = hardwareMap.get(DcMotor.class, "frontRight_motor"); // the right drivetrain motor
-        rearLeftDrive = hardwareMap.get(DcMotor.class, "rearLeft_motor"); // the left drivetrain motor
-        rearRightDrive = hardwareMap.get(DcMotor.class, "rearRight_motor"); // the right drivetrain motor`1
+        frontLeftDrive.setDirection(DcMotorSimple.Direction.REVERSE);
+        rearLeftDrive.setDirection(DcMotorSimple.Direction.REVERSE);
+    }
 
+    @Override
+    public void loop() {
 
-        while (opModeIsActive()) {
-
-        }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
@@ -1,0 +1,104 @@
+/*   MIT License
+ *   Copyright (c) [2024] [Base 10 Assets, LLC]
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+package org.firstinspires.ftc.teamcode.teamcode;
+
+import androidx.fragment.app.FragmentContainer;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.hardware.CRServo;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.Servo;
+
+import org.firstinspires.ftc.robotcore.external.navigation.CurrentUnit;
+
+/*
+ * This OpMode is an example driver-controlled (TeleOp) mode for the goBILDA 2024-2025 FTC
+ * Into The Deep Starter Robot
+ * The code is structured as a LinearOpMode
+ *
+ * This robot has a two-motor differential-steered (sometimes called tank or skid steer) drivetrain.
+ * With a left and right drive motor.
+ * The drive on this robot is controlled in an "Arcade" style, with the left stick Y axis
+ * controlling the forward movement and the right stick X axis controlling rotation.
+ * This allows easy transition to a standard "First Person" control of a
+ * mecanum or omnidirectional chassis.
+ *
+ * The drive wheels are 96mm diameter traction (Rhino) or omni wheels.
+ * They are driven by 2x 5203-2402-0019 312RPM Yellow Jacket Planetary Gearmotors.
+ *
+ * This robot's main scoring mechanism includes an arm powered by a motor, a "wrist" driven
+ * by a servo, and an intake driven by a continuous rotation servo.
+ *
+ * The arm is powered by a 5203-2402-0051 (50.9:1 Yellow Jacket Planetary Gearmotor) with an
+ * external 5:1 reduction. This creates a total ~254.47:1 reduction.
+ * This OpMode uses the motor's encoder and the RunToPosition method to drive the arm to
+ * specific setpoints. These are defined as a number of degrees of rotation away from the arm's
+ * starting position.
+ *
+ * Make super sure that the arm is reset into the robot, and the wrist is folded in before
+ * you run start the OpMode. The motor's encoder is "relative" and will move the number of degrees
+ * you request it to based on the starting position. So if it starts too high, all the motor
+ * setpoints will be wrong.
+ *
+ * The wrist is powered by a goBILDA Torque Servo (2000-0025-0002).
+ *0.
+ * The intake wheels are powered by a goBILDA Speed Servo (2000-0025-0003) in Continuous Rotation mode.
+ */
+
+@TeleOp(name = "Decode2025RobotCode_TeleOp", group = "Robot")
+// @Disabled
+public class Decode2025RobotCode_TeleOp extends LinearOpMode {
+
+    /* Declare OpMode members. */
+    public DcMotor  frontLeftDrive = null; //the left drivetrain motor
+    public DcMotor  frontRightDrive  = null; //the right drivetrain motor
+    public DcMotor  rearLeftDrive = null; //the left drivetrain motor
+    public DcMotor  rearRightDrive  = null; //the right drivetrain motor
+
+
+    @Override
+    public void runOpMode() {
+        /*
+         * These variables are private to the OpMode, and are used to control the
+         * drivetrain.
+         */
+        double left;
+        double right;
+        double forward;
+        double rotate;
+        double max;
+
+        /* Define and Initialize Motors */
+        frontLeftDrive = hardwareMap.get(DcMotor.class, "frontLeft_motor"); // the left drivetrain motor
+        frontRightDrive = hardwareMap.get(DcMotor.class, "frontRight_motor"); // the right drivetrain motor
+        rearLeftDrive = hardwareMap.get(DcMotor.class, "rearLeft_motor"); // the left drivetrain motor
+        rearRightDrive = hardwareMap.get(DcMotor.class, "rearRight_motor"); // the right drivetrain motor`1
+
+
+        while (opModeIsActive()) {
+
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teamcode/Decode2025RobotCode_TeleOp.java
@@ -1,10 +1,12 @@
 package org.firstinspires.ftc.teamcode.teamcode;
 
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.IMU;
 import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 
@@ -17,6 +19,8 @@ public class Decode2025RobotCode_TeleOp extends OpMode {
     public DcMotor rearLeftDrive = null;
     public DcMotor rearRightDrive  = null;
 
+    private IMU imu;
+
     @Override
     public void init() {
         frontLeftDrive = hardwareMap.get(DcMotor.class, "frontLeft_motor");
@@ -26,10 +30,30 @@ public class Decode2025RobotCode_TeleOp extends OpMode {
 
         frontLeftDrive.setDirection(DcMotorSimple.Direction.REVERSE);
         rearLeftDrive.setDirection(DcMotorSimple.Direction.REVERSE);
+
+        frontLeftDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        frontRightDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rearLeftDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rearRightDrive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+
+        imu = hardwareMap.get(IMU.class, "imu");
+
+        RevHubOrientationOnRobot RevOrientation = new RevHubOrientationOnRobot(
+                RevHubOrientationOnRobot.LogoFacingDirection.UP,
+                RevHubOrientationOnRobot.UsbFacingDirection.FORWARD);
+
+        imu.initialize(new IMU.Parameters(RevOrientation));
     }
 
+    public void drive(double forward, double strafe, double rotate) {
+        double frontLeftDrive = forward + strafe + rotate;
+        double rearLeftDrive = forward - strafe + rotate;
+        double frontRightDrive = forward - strafe - rotate;
+        double rearRightDrive = forward + strafe - rotate;
+    }
     @Override
     public void loop() {
 
     }
 }
+


### PR DESCRIPTION
Add mecanum drive TeleOp class for "Robot relative" driving.
- mapped motor hardware and set left motors to reverse
- added generic drive method that takes in value "forward, strafe, rotate" from gamepad1 joysticks to calculate each motor (wheel) power to set for desired direction.
- added IMU mapping for possible use later, if the team decides they would like "Field relative" operation.